### PR TITLE
修复 87c071:合并271分支 的参数遗漏

### DIFF
--- a/src/main/java/com/genersoft/iot/vmp/storager/impl/RedisCatchStorageImpl.java
+++ b/src/main/java/com/genersoft/iot/vmp/storager/impl/RedisCatchStorageImpl.java
@@ -694,6 +694,7 @@ public class RedisCatchStorageImpl implements IRedisCatchStorage {
     @Override
     public void addPushListItem(String app, String stream, MediaArrivalEvent event) {
         String key = VideoManagerConstants.PUSH_STREAM_LIST + app + "_" + stream;
+        event.getHookParam().setSeverId(userSetting.getServerId());
         redisTemplate.opsForValue().set(key, event.getHookParam());
     }
 


### PR DESCRIPTION
将推流信息记录至redis，由StreamPushItem变更成OnStreamChangedHookParam时，漏了设置serverId。